### PR TITLE
Problem: fty-info loses information

### DIFF
--- a/src/fty_info_server.cc
+++ b/src/fty_info_server.cc
@@ -112,6 +112,7 @@ char *s_get_name(const char *name, const char *uuid)
 //    - subtype _powerservice._sub._https._tcp.
 //    - port    443
 //    - hashtable : TXT name, TXT value
+//          id (internal id "rackcontroller-33")
 //          uuid
 //          name (meaning user-friendly name)
 //          name_uri

--- a/src/ftyinfo.cc
+++ b/src/ftyinfo.cc
@@ -38,6 +38,7 @@
 
 struct _ftyinfo_t {
     zhash_t *infos;
+    char *id;
     char *uuid;
     char *hostname;
     char *name;
@@ -112,13 +113,17 @@ ftyinfo_new (topologyresolver_t *resolver)
     zstr_free (&hostname);
     zsys_info ("fty-info:hostname  = '%s'", self->hostname);
 
+    //set id
+    self->id = strdup (topologyresolver_id (resolver));
+    zsys_info ("fty-info:id        = '%s'", self->id);
+
     //set name
     self->name = topologyresolver_to_rc_name (resolver);
     zsys_info ("fty-info:name      = '%s'", self-> name);
 
     //set name_uri
     self->name_uri = topologyresolver_to_rc_name_uri (resolver);
-    zsys_info ("fty-info:name_uri      = '%s'", self-> name_uri);
+    zsys_info ("fty-info:name_uri  = '%s'", self-> name_uri);
 
     //set location
     self->location = strdup (topologyresolver_to_string (resolver, ">"));
@@ -126,7 +131,7 @@ ftyinfo_new (topologyresolver_t *resolver)
 
     //set parent_uri
     self->parent_uri = topologyresolver_to_parent_uri (resolver);
-    zsys_info ("fty-info:parent_uri  = '%s'", self->parent_uri);
+    zsys_info ("fty-info:parent_uri= '%s'", self->parent_uri);
 
     //set uuid, vendor, model from /etc/release-details.json
     cxxtools::SerializationInfo *si = nullptr;
@@ -169,6 +174,7 @@ ftyinfo_test_new (void)
     ftyinfo_t *self = (ftyinfo_t *) zmalloc (sizeof (ftyinfo_t));
     // TXT attributes
     self->infos     = zhash_new();
+    self->id        = strdup (TST_ID);
     self->uuid      = strdup (TST_UUID);
     self->hostname  = strdup (TST_HOSTNAME);
     self->name      = strdup (TST_NAME);
@@ -199,6 +205,7 @@ ftyinfo_destroy (ftyinfo_t **self_ptr)
         ftyinfo_t *self = *self_ptr;
         // Free class properties here
         zhash_destroy(&self->infos);
+        zstr_free (&self->id);
         zstr_free (&self->uuid);
         zstr_free (&self->hostname);
         zstr_free (&self->name);

--- a/src/ftyinfo.h
+++ b/src/ftyinfo.h
@@ -38,6 +38,7 @@ extern "C" {
 #define TXT_VER  "1"
 
 //test value for INFO-TEST command reply
+#define TST_ID          "rackcontroller-2"
 #define TST_UUID        "ce7c523e-08bf-11e7-af17-080027d52c4f"
 #define TST_HOSTNAME    "localhost"
 #define TST_NAME        "MyIPC"

--- a/src/topologyresolver.cc
+++ b/src/topologyresolver.cc
@@ -208,12 +208,24 @@ topologyresolver_destroy (topologyresolver_t **self_p)
 }
 
 //  --------------------------------------------------------------------------
+//  get RC internal name
+
+const char *
+topologyresolver_id (topologyresolver_t *self)
+{
+    if (! self || ! self->iname) return "NA";
+    return  self->iname;
+}
+
+//  --------------------------------------------------------------------------
 //  Give topology resolver one asset information
 void
 topologyresolver_asset (topologyresolver_t *self, fty_proto_t *message)
 {
     if (! self || ! message) return;
     if (fty_proto_id (message) != FTY_PROTO_ASSET) return;
+    const char *operation = fty_proto_operation (message);
+    if (operation && streq (operation, "inventory")) return;
 
     if (!self->iname && s_is_this_me (message)) {
         self->iname = strdup (fty_proto_name (message));

--- a/src/topologyresolver.h
+++ b/src/topologyresolver.h
@@ -35,6 +35,10 @@ FTY_INFO_PRIVATE topologyresolver_t *
 FTY_INFO_PRIVATE void
     topologyresolver_destroy (topologyresolver_t **self_p);
 
+//  get RC internal name
+FTY_INFO_PRIVATE const char *
+    topologyresolver_id (topologyresolver_t *self);
+
 // Return URI of asset for this topologyresolver
 FTY_INFO_PRIVATE char *
     topologyresolver_to_rc_name_uri (topologyresolver_t *self);


### PR DESCRIPTION
Solution: Ignore inventory message (this can carry incomplete
information). Add internal id to message (rackcontroller-XY).

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>