### PR TITLE
Problem: CLI parsing is not following usage()

### DIFF
--- a/include/fty_info.h
+++ b/include/fty_info.h
@@ -22,12 +22,23 @@
 #ifndef FTY_INFO_H_H_INCLUDED
 #define FTY_INFO_H_H_INCLUDED
 
+#include <iostream>
+#include <sstream>
+#include <cstddef>
+#include <map>
+
+using namespace std;
+
 //  Include the project library file
 #include "fty_info_library.h"
 
 //  Add your own public definitions here, if you need them
 #define FTY_INFO_AGENT "fty-info"
 #define FTY_INFO_CMD "INFO"
+#define DEFAULT_ANNOUNCE_INTERVAL_SEC   60
+
+// TODO: get from config
+// #define TIMEOUT_MS -1   //wait infinitely
 
 #define INFO_ID        "id"
 #define INFO_UUID      "uuid"
@@ -49,5 +60,11 @@
 #define INFO_PROTOCOL_FORMAT "protocol-format"
 #define INFO_TYPE      "type"
 #define INFO_TXTVERS   "txtvers"
+
+// Config file accessors
+const char* s_get (zconfig_t *config, const char* key, std::string &dfl);
+const char* s_get (zconfig_t *config, const char* key, const char*dfl);
+
+#define my_zsys_debug(verbose, ...) { if (verbose) zsys_debug (__VA_ARGS__); }
 
 #endif

--- a/src/fty-info.cfg.in
+++ b/src/fty-info.cfg.in
@@ -1,9 +1,12 @@
 #   fty-info configuration
-# This is a skeleton created by zproject.
-# You can add hand-written code here.
 
 server
     timeout = 10000     #   Client connection timeout, msec
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     verbose = 0         #   Do verbose logging of activity?
+    announce = 60       #   Frequiency of announcements (in seconds)
+
+malamute
+    endpoint = ipc://@/malamute #   Malamute endpoint
+    address = fty-info          #   Agent address

--- a/src/fty-info.service.in
+++ b/src/fty-info.service.in
@@ -22,7 +22,7 @@ EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
-ExecStart=@prefix@/bin/fty-info @sysconfdir@/@PACKAGE@/fty-info.cfg
+ExecStart=@prefix@/bin/fty-info -c @sysconfdir@/@PACKAGE@/fty-info.cfg
 
 [Install]
 WantedBy=bios.target

--- a/src/fty_info_server.cc
+++ b/src/fty_info_server.cc
@@ -51,6 +51,26 @@ struct _fty_info_server_t {
     topologyresolver_t* resolver;
 };
 
+// Configuration accessors
+// FIXME: why do we need that? zconfig_get should already do this, no?
+const char*
+s_get (zconfig_t *config, const char* key, std::string &dfl) {
+    assert (config);
+    char *ret = zconfig_get (config, key, dfl.c_str());
+    if (!ret || streq (ret, ""))
+        return (char*)dfl.c_str();
+    return ret;
+}
+
+const char*
+s_get (zconfig_t *config, const char* key, const char*dfl) {
+    assert (config);
+    char *ret = zconfig_get (config, key, dfl);
+    if (!ret || streq (ret, ""))
+        return dfl;
+    return ret;
+}
+
 //  --------------------------------------------------------------------------
 //  Create a new fty_info_server
 


### PR DESCRIPTION
Solution: add support for missing arguments, including cfg-file parsing

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Hope I got this right - but please do review the code just in case (especially if everything is free()d properly etc.)