### PR TITLE
Problem: zmsg object not created for 'else' branch

### DIFF
--- a/src/fty_info_server.cc
+++ b/src/fty_info_server.cc
@@ -585,6 +585,8 @@ s_handle_mailbox(fty_info_server_t* self,zmsg_t *message)
     }
     else {
         zsys_warning ("fty-info: Received unexpected command '%s'", command);
+
+        reply = zmsg_new ();
         if (NULL != zuuid)
             zmsg_addstr (reply, zuuid);
 


### PR DESCRIPTION
Solution: object created when 'else' entered

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>